### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         java-version: ${{ matrix.java_version }}
     - name: Build and test Java ${{ matrix.java_version }}
       run: |
-        mvn -B clean test -PJava${{ matrix.java_version }}
+        mvn -B clean test -PJava${{ matrix.java_version }} -DdisableXmlReport=true
 
         
   DeployArtifacts:


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime. The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.